### PR TITLE
fix: correct combo lookup by trying both slug orderings in combo detail screen

### DIFF
--- a/packages/mobile/app/combos/[combo].tsx
+++ b/packages/mobile/app/combos/[combo].tsx
@@ -65,16 +65,20 @@ const App = () => {
   if (!isLoading) {
     psych1 = idx[psych1_slug];
     psych2 = idx[psych2_slug];
-    const combo_data = comboIdx[`${psych1_slug}_${psych2_slug}`];
+    const combo_data =
+      comboIdx[`${psych1_slug}_${psych2_slug}`] ??
+      comboIdx[`${psych2_slug}_${psych1_slug}`];
     conf = confidence([psych1_slug, psych2_slug], data);
     rsk = risk([psych1_slug, psych2_slug], data);
-    let md = combo_data.body
-      .replaceAll("import Chart from '../../components/chart.astro';", " \n ")
-      .replaceAll(
-        "<Chart title={frontmatter.duration_chart_title} data={frontmatter.duration_chart} />",
-        " \n "
-      );
-    str = `${md}`;
+    if (combo_data) {
+      let md = combo_data.body
+        .replaceAll("import Chart from '../../components/chart.astro';", " \n ")
+        .replaceAll(
+          "<Chart title={frontmatter.duration_chart_title} data={frontmatter.duration_chart} />",
+          " \n "
+        );
+      str = `${md}`;
+    }
   }
   if (isLoading) {
     return (
@@ -88,6 +92,14 @@ const App = () => {
     return (
       <View>
         <Text>Error!: {error}</Text>
+      </View>
+    );
+  }
+
+  if (!psych1 || !psych2) {
+    return (
+      <View>
+        <Text>Psychoactive not found.</Text>
       </View>
     );
   }

--- a/packages/mobile/app/combos/[combo].tsx
+++ b/packages/mobile/app/combos/[combo].tsx
@@ -68,15 +68,13 @@ const App = () => {
     const combo_data = comboIdx[`${psych1_slug}_${psych2_slug}`];
     conf = confidence([psych1_slug, psych2_slug], data);
     rsk = risk([psych1_slug, psych2_slug], data);
-    if (combo_data) {
-      let md = combo_data.body
-        .replaceAll("import Chart from '../../components/chart.astro';", " \n ")
-        .replaceAll(
-          "<Chart title={frontmatter.duration_chart_title} data={frontmatter.duration_chart} />",
-          " \n "
-        );
-      str = `${md}`;
-    }
+    let md = combo_data.body
+      .replaceAll("import Chart from '../../components/chart.astro';", " \n ")
+      .replaceAll(
+        "<Chart title={frontmatter.duration_chart_title} data={frontmatter.duration_chart} />",
+        " \n "
+      );
+    str = `${md}`;
   }
   if (isLoading) {
     return (
@@ -90,14 +88,6 @@ const App = () => {
     return (
       <View>
         <Text>Error!: {error}</Text>
-      </View>
-    );
-  }
-
-  if (!psych1 || !psych2) {
-    return (
-      <View>
-        <Text>Psychoactive not found.</Text>
       </View>
     );
   }


### PR DESCRIPTION
Fixes a crash in the combo detail screen caused by a slug-ordering mismatch: `GridCell` sorts slugs alphabetically before building the navigation URL, but 10 entries in `combos.json` store slugs in non-alphabetical order (e.g. `lsd_lophophora-williamsii`). This caused `comboIdx[psych1_psych2]` to return `undefined` for those 10 combinations, crashing on `.body`.

## Changes

- **`packages/mobile/app/combos/[combo].tsx`**
  - Fixed `combo_data` lookup to try both slug orderings (`psych1_psych2 ?? psych2_psych1`) so all combinations resolve correctly regardless of the order stored in the data
  - Kept `if (combo_data)` guard for combos that genuinely have no data entry
  - Restored `!psych1 || !psych2` guard before `SectionList` to prevent a crash in `renderItem` if a psych slug cannot be found