### PR TITLE
Revert "fix: correct combo lookup by trying both slug orderings in combo detail screen"

### DIFF
--- a/packages/mobile/app/combos/[combo].tsx
+++ b/packages/mobile/app/combos/[combo].tsx
@@ -65,9 +65,7 @@ const App = () => {
   if (!isLoading) {
     psych1 = idx[psych1_slug];
     psych2 = idx[psych2_slug];
-    const combo_data =
-      comboIdx[`${psych1_slug}_${psych2_slug}`] ??
-      comboIdx[`${psych2_slug}_${psych1_slug}`];
+    const combo_data = comboIdx[`${psych1_slug}_${psych2_slug}`];
     conf = confidence([psych1_slug, psych2_slug], data);
     rsk = risk([psych1_slug, psych2_slug], data);
     if (combo_data) {


### PR DESCRIPTION
Reverts mastfissh/psychcombo#54